### PR TITLE
Matt: allowing for external timeouts to be passed to Autostacker, updating depencies

### DIFF
--- a/autocanary24.gemspec
+++ b/autocanary24.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'autostacker24', '~> 1.0'
+  spec.add_dependency 'autostacker24', '~> 2.0.2'
   spec.add_dependency 'aws-sdk-core', '~> 2'
 
   spec.add_development_dependency "bundler", "~> 1.11"

--- a/autocanary24.gemspec
+++ b/autocanary24.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'autostacker24', '~> 2.0.2'
+  spec.add_dependency 'autostacker24', '~> 2.1.0'
   spec.add_dependency 'aws-sdk-core', '~> 2'
 
   spec.add_development_dependency "bundler", "~> 1.11"

--- a/lib/autocanary24/client.rb
+++ b/lib/autocanary24/client.rb
@@ -179,11 +179,11 @@ module AutoCanary24
 
     def create_stack(stack_name, template, parameters, parent_stack_name, tags)
       write_log(stack_name, "Create/Update stack")
-      Stacker.create_or_update_stack(stack_name, template, parameters, parent_stack_name, tags)
+      Stacker.create_or_update_stack(stack_name, template, parameters, parent_stack_name, tags, @configuration.wait_timeout)
     end
 
     def delete_stack(stack_name)
-      Stacker.delete_stack(stack_name) unless stack_name.nil?
+      Stacker.delete_stack(stack_name, @configuration.wait_timeout) unless stack_name.nil?
     end
 
     def get_canary_stack(stack_name)


### PR DESCRIPTION
This is dependent upon https://github.com/AutoScout24/autostacker24/pull/27

Do not merge until https://github.com/AutoScout24/autostacker24/pull/27 is merged and published.

-Matt