### PR TITLE
Release 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Unreleased Changes
 ------------------
 
+0.3.0 (2016-07-05)
+------------------
+* Feature - We now ensuring that `wait_timeout` is passed through to Autostacker24.
+
 0.2.1 (2016-05-25)
 ------------------
 * Issue - Unable to deploy stack with higher AutoScalingGroup min-size than the currently running one

--- a/lib/autocanary24/version.rb
+++ b/lib/autocanary24/version.rb
@@ -1,3 +1,3 @@
 module AutoCanary24
-  VERSION = "0.2.1"
+  VERSION = "0.3.0"
 end


### PR DESCRIPTION
We now ensuring that `wait_timeout` is passed through to Autostacker24.